### PR TITLE
fix: Real 1px lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,15 @@ fn App<G: Html>(ctx: BoundedScope) -> View<G> {
     let is_mounted = create_signal(ctx, false);
 
     on_mount(ctx, || {
+        let canvas: HtmlCanvasElement = canvas_ref.get::<DomNode>().unchecked_into();
+        let ctx = canvas
+            .get_context("2d")
+            .expect("should get context")
+            .unwrap()
+            .dyn_into::<web_sys::CanvasRenderingContext2d>()
+            .expect("should cast to context");
+        ctx.translate(0.5, 0.5).unwrap();
+
         let window = web_sys::window().expect("should have a window in this context");
         let app_state_cloned = app_state.clone();
         let handler = move |event: KeyboardEvent| {


### PR DESCRIPTION
- [[bd515f7: Real 1px lines](https://github.com/excalidraw/excalidraw/commit/bd515f7e50747356765dddb070364e5494b9fd64)](https://github.com/excalidraw/excalidraw/commit/bd515f7e50747356765dddb070364e5494b9fd64) [[2022-12-16]]  
	- https://stackoverflow.com/questions/13879322/drawing-a-1px-thick-line-in-canvas-creates-a-2px-thick-line/13879402#comment90766599_13879402  
	- Big hack to ensure that all the 1px lines are drawn at 1px instead of 2px