### PR TITLE
fix: clearRect for [0, 0.5]

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -122,6 +122,6 @@ impl Painter {
             .expect("should cast to context");
         let canvas_width = html_canvas_element.width();
         let canvas_height = html_canvas_element.height();
-        ctx.clear_rect(0.0, 0.0, canvas_width as f64, canvas_height as f64);
+        ctx.clear_rect(-0.5, -0.5, canvas_width as f64, canvas_height as f64);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -102,7 +102,7 @@ impl AppState {
 
     pub fn move_selected_elements(&self, arrow: ArrowDirection, step: i32) {
         tracing::info!("Moving selected elements");
-        let elements = self.elements.get();
+        let elements = self.elements.take_silent();
         elements.iter().for_each(|re_element| {
             let element = re_element.get();
             if element.is_selected {
@@ -126,5 +126,6 @@ impl AppState {
                 }
             }
         });
+        self.elements.set(elements.to_vec());
     }
 }


### PR DESCRIPTION
[ee7dc95: Fix clearRect for [0, 0.5]](https://github.com/excalidraw/excalidraw/commit/ee7dc953bfcc451a04f9570d85703b960cccd921)